### PR TITLE
Add profile, password change, favorites, CSV export and API

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -162,6 +162,18 @@
                 <li class="nav-item mb-3">
                     <a class="nav-link" href="{{ url_for('my_bookings') }}">✈️ My Bookings</a>
                 </li>
+                <li class="nav-item mb-3">
+                    <a class="nav-link" href="{{ url_for('favorites') }}">⭐ Favorites</a>
+                </li>
+                <li class="nav-item mb-3">
+                    <a class="nav-link" href="{{ url_for('profile') }}">👤 Profile</a>
+                </li>
+                <li class="nav-item mb-3">
+                    <a class="nav-link" href="{{ url_for('change_password') }}">🔒 Change Password</a>
+                </li>
+                <li class="nav-item mb-3">
+                    <a class="nav-link" href="{{ url_for('download_bookings') }}">📥 Download Bookings</a>
+                </li>
                 {% if current_user.is_admin %}
                     <li class="nav-item mb-3">
                         <a class="nav-link" href="{{ url_for('admin') }}">🛠 Admin Panel</a>

--- a/templates/change_password.html
+++ b/templates/change_password.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Change Password</h1>
+<form method="POST">
+    <div class="mb-3">
+        <label>Current Password</label>
+        <input type="password" name="current_password" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label>New Password</label>
+        <input type="password" name="new_password" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label>Confirm Password</label>
+        <input type="password" name="confirm_password" class="form-control">
+    </div>
+    <button type="submit" class="btn btn-primary">Change</button>
+</form>
+{% endblock %}

--- a/templates/favorites.html
+++ b/templates/favorites.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-center">My Favorite Flights</h1>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Departure</th>
+            <th>Arrival</th>
+            <th>Date</th>
+            <th>Price</th>
+            <th>Seats</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for flight in flights %}
+        <tr>
+            <td>{{ flight.departure_city }}</td>
+            <td>{{ flight.arrival_city }}</td>
+            <td>{{ flight.date }}</td>
+            <td>{{ flight.price }}</td>
+            <td>{{ flight.available_seats }}</td>
+            <td>
+                <form method="post" action="{{ url_for('toggle_favorite', flight_id=flight.id) }}">
+                    <button type="submit" class="btn btn-warning">Remove</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,6 +56,15 @@
             <td>{{ flight.available_seats }}</td>
             <td>
                 <a href="{{ url_for('book_flight', flight_id=flight.id) }}" class="btn btn-success">Book</a>
+                {% if current_user.is_authenticated %}
+                <form method="post" action="{{ url_for('toggle_favorite', flight_id=flight.id) }}" style="display:inline;">
+                    {% if flight.id in favorite_ids %}
+                    <button type="submit" class="btn btn-warning">Unfavorite</button>
+                    {% else %}
+                    <button type="submit" class="btn btn-warning">Favorite</button>
+                    {% endif %}
+                </form>
+                {% endif %}
             </td>
         </tr>
         {% endfor %}

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <h1 class="text-center">My Bookings</h1>
+<a href="{{ url_for('download_bookings') }}" class="btn btn-primary mb-3">Download CSV</a>
 <table>
     <thead>
         <tr>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>My Profile</h1>
+<form method="POST">
+    <div class="mb-3">
+        <label>Username</label>
+        <input type="text" name="username" class="form-control" value="{{ current_user.username }}">
+    </div>
+    <div class="mb-3">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control" value="{{ current_user.email }}">
+    </div>
+    <div class="mb-3">
+        <label>Phone</label>
+        <input type="text" name="phone" class="form-control" value="{{ current_user.phone or '' }}">
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Allow users to edit profile information including phone number
- Enable users to change their passwords
- Let users favorite flights and manage them in a dedicated page
- Provide CSV download of personal bookings
- Expose a public API endpoint listing all flights

## Testing
- `python -m py_compile app.py database/app1.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9c4e4d9088333b3be529b0afc141d